### PR TITLE
Add rate limiter middleware to ClickUp router

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "syncup",
       "dependencies": {
         "hono": "^4.9.9",
+        "hono-rate-limiter": "^0.4.2",
         "ioredis": "^5.8.0",
         "pino": "^9.11.0",
         "zod": "^4.1.11",
@@ -54,6 +55,8 @@
     "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
 
     "hono": ["hono@4.9.9", "", {}, "sha512-Hxw4wT6zjJGZJdkJzAx9PyBdf7ZpxaTSA0NfxqjLghwMrLBX8p33hJBzoETRakF3UJu6OdNQBZAlNSkGqKFukw=="],
+
+    "hono-rate-limiter": ["hono-rate-limiter@0.4.2", "", { "peerDependencies": { "hono": "^4.1.1" } }, "sha512-AAtFqgADyrmbDijcRTT/HJfwqfvhalya2Zo+MgfdrMPas3zSMD8SU03cv+ZsYwRU1swv7zgVt0shwN059yzhjw=="],
 
     "ioredis": ["ioredis@5.8.0", "", { "dependencies": { "@ioredis/commands": "1.4.0", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-AUXbKn9gvo9hHKvk6LbZJQSKn/qIfkWXrnsyL9Yrf+oeXmla9Nmf6XEumOddyhM8neynpK5oAV6r9r99KBuwzA=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "hono": "^4.9.9",
+    "hono-rate-limiter": "^0.4.2",
     "ioredis": "^5.8.0",
     "pino": "^9.11.0",
     "zod": "^4.1.11"

--- a/src/helpers/RateLimit.ts
+++ b/src/helpers/RateLimit.ts
@@ -1,0 +1,21 @@
+import { rateLimiter } from "hono-rate-limiter";
+import { getConnInfo } from "hono/bun";
+export const limiter = rateLimiter({
+  windowMs: 60 * 1000, // 1 min
+  limit: 10, // 10 requests per windowMs
+
+  keyGenerator: (c) => {
+    return (
+      c.req.header("x-forwarded-for") ??
+      c.req.header("cf-connecting-ip") ??
+      getConnInfo(c).remote.address ??
+      "unknown"
+    );
+  },
+  handler: async (c) => {
+    return c.json(
+      { message: "Too many requests, please try again later." },
+      429
+    );
+  },
+});

--- a/src/routing/ClickupRouter.ts
+++ b/src/routing/ClickupRouter.ts
@@ -6,8 +6,10 @@ import { RedisStore } from "../stores/RedisStore";
 import { GenerateAuthUrlUseCase } from "../useCases/clickup/GenerateAuthUrlUseCase";
 import { ConnectClickUpAccountUseCase } from "../useCases/clickup/ConnectClickUpAccountUseCase";
 import { logger } from "../config/Logger";
+import { limiter } from "../helpers/RateLimit";
 
 export const ClickupRouter = new Hono();
+ClickupRouter.use(limiter);
 
 ClickupRouter.get("/auth", async (c) => {
   const code = c.req.query("code");


### PR DESCRIPTION
Introduce a rate limiter to the ClickUp router to manage request limits and prevent abuse. Update dependencies to include the new rate limiter package.